### PR TITLE
Update charts repository URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 UPSTREAM_GIT_URL = https://github.com/fairfaxmedia/charts.git
-CHARTS_URL = https://fairfaxmedia.github.io/charts
+CHARTS_URL = https://charts.ffx.io/charts
 COMMIT = $(shell git rev-parse --short HEAD)
 
 .PHONY: clean build publish

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Get the latest [Helm release](https://github.com/kubernetes/helm#install).
 ### Add Helm chart repository:
 
  ```console
- helm repo add fairfaxmedia https://fairfaxmedia.github.io/charts/
+ helm repo add fairfaxmedia https://charts.ffx.io/charts/
  helm repo update
  ```
 


### PR DESCRIPTION
Switches from `fairfaxmedia.github.io` to `charts.ffx.io`.
