### PR TITLE
Repository is at the root level of gh-pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Get the latest [Helm release](https://github.com/kubernetes/helm#install).
 ### Add Helm chart repository:
 
  ```console
- helm repo add fairfaxmedia https://charts.ffx.io/charts/
+ helm repo add fairfaxmedia https://charts.ffx.io/
  helm repo update
  ```
 


### PR DESCRIPTION
Repository is at the root level of github pages. No need to specify a sub directory.