### PR TITLE
Define default affinity

### DIFF
--- a/stable/elasticsearch/Chart.yaml
+++ b/stable/elasticsearch/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "6.5.1"
 description: A Helm chart for Elasticsearch
 name: elasticsearch
 icon: https://www.elastic.co/static/images/elastic-logo-200.png
-version: 1.1.0-elasticsearch6.5.1
+version: 1.1.1-elasticsearch6.5.1
 maintainers:
   - name: Fairfax Media Operations
     email: github@fairfaxmedia.com.au

--- a/stable/elasticsearch/templates/client-deploy.yaml
+++ b/stable/elasticsearch/templates/client-deploy.yaml
@@ -134,10 +134,40 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.client.affinity }}
       affinity:
+      {{- if .Values.client.affinity }}
+        {{- with .Values.client.affinity }}
 {{ toYaml . | indent 8 }}
-    {{- end }}
+        {{- end }}
+      {{- else }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                - {{ include "elasticsearch.name" . }}
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                - client
+            topologyKey: "kubernetes.io/hostname"
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - {{ include "elasticsearch.name" . }}
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                  - client
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+      {{- end }}
     {{- with .Values.client.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}

--- a/stable/elasticsearch/templates/data-statefulset.yaml
+++ b/stable/elasticsearch/templates/data-statefulset.yaml
@@ -17,11 +17,6 @@ spec:
   podManagementPolicy: {{ .Values.podManagementPolicy | default "Parallel" }}
   updateStrategy:
     type: {{ .Values.data.strategyType | default "OnDelete" }}
-    {{- if eq .Values.data.strategyType "RollingUpdate" }}
-    rollingUpdate:
-      maxUnavailable: 0
-      maxSurge: 1
-    {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "elasticsearch.name" . }}
@@ -148,10 +143,40 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.data.affinity }}
       affinity:
+      {{- if .Values.data.affinity }}
+        {{- with .Values.data.affinity }}
 {{ toYaml . | indent 8 }}
-    {{- end }}
+        {{- end }}
+      {{- else }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                - {{ include "elasticsearch.name" . }}
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                - data
+            topologyKey: "kubernetes.io/hostname"
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - {{ include "elasticsearch.name" . }}
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                  - data
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+      {{- end }}
     {{- with .Values.data.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}

--- a/stable/elasticsearch/templates/master-statefulset.yaml
+++ b/stable/elasticsearch/templates/master-statefulset.yaml
@@ -17,11 +17,6 @@ spec:
   podManagementPolicy: {{ .Values.podManagementPolicy | default "Parallel" }}
   updateStrategy:
     type: {{ .Values.master.strategyType | default "OnDelete" }}
-    {{- if eq .Values.master.strategyType "RollingUpdate" }}
-    rollingUpdate:
-      maxUnavailable: 0
-      maxSurge: 1
-    {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "elasticsearch.name" . }}
@@ -148,10 +143,40 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.master.affinity }}
       affinity:
+      {{- if .Values.master.affinity }}
+        {{- with .Values.master.affinity }}
 {{ toYaml . | indent 8 }}
-    {{- end }}
+        {{- end }}
+      {{- else }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                - {{ include "elasticsearch.name" . }}
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                - master
+            topologyKey: "kubernetes.io/hostname"
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - {{ include "elasticsearch.name" . }}
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                  - master
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+      {{- end }}
     {{- with .Values.master.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}

--- a/stable/elasticsearch/tests/__snapshot__/client-deploy_test.yaml.snap
+++ b/stable/elasticsearch/tests/__snapshot__/client-deploy_test.yaml.snap
@@ -19,6 +19,34 @@ has defaults:
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: elasticsearch
       spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                    - elasticsearch
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                    - client
+                topologyKey: failure-domain.beta.kubernetes.io/zone
+              weight: 100
+            requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - elasticsearch
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                  - client
+              topologyKey: kubernetes.io/hostname
         containers:
         - env:
           - name: ES_NODE_NAME

--- a/stable/elasticsearch/tests/__snapshot__/data-statefulset_test.yaml.snap
+++ b/stable/elasticsearch/tests/__snapshot__/data-statefulset_test.yaml.snap
@@ -16,6 +16,34 @@ has defaults:
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: elasticsearch
       spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                    - elasticsearch
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                    - data
+                topologyKey: failure-domain.beta.kubernetes.io/zone
+              weight: 100
+            requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - elasticsearch
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                  - data
+              topologyKey: kubernetes.io/hostname
         containers:
         - env:
           - name: ES_NODE_NAME

--- a/stable/elasticsearch/tests/__snapshot__/master-statefulset_test.yaml.snap
+++ b/stable/elasticsearch/tests/__snapshot__/master-statefulset_test.yaml.snap
@@ -16,6 +16,34 @@ has defaults:
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: elasticsearch
       spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                    - elasticsearch
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                    - master
+                topologyKey: failure-domain.beta.kubernetes.io/zone
+              weight: 100
+            requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - elasticsearch
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                  - master
+              topologyKey: kubernetes.io/hostname
         containers:
         - env:
           - name: ES_NODE_NAME
@@ -107,7 +135,4 @@ has defaults:
             name: RELEASE-NAME-elasticsearch
           name: settings
     updateStrategy:
-      rollingUpdate:
-        maxSurge: 1
-        maxUnavailable: 0
       type: RollingUpdate

--- a/stable/elasticsearch/tests/client-deploy_test.yaml
+++ b/stable/elasticsearch/tests/client-deploy_test.yaml
@@ -135,8 +135,36 @@ tests:
                   path: elasticsearch_custom.yml
       - isEmpty:
           path: spec.template.spec.nodeSelector
-      - isEmpty:
+      - equal:
           path: spec.template.spec.affinity
+          value:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: app.kubernetes.io/name
+                      operator: In
+                      values:
+                      - elasticsearch
+                    - key: app.kubernetes.io/component
+                      operator: In
+                      values:
+                      - client
+                  topologyKey: failure-domain.beta.kubernetes.io/zone
+                weight: 100
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                    - elasticsearch
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                    - client
+                topologyKey: kubernetes.io/hostname
       - isEmpty:
           path: spec.template.spec.tolerations
 

--- a/stable/elasticsearch/tests/data-statefulset_test.yaml
+++ b/stable/elasticsearch/tests/data-statefulset_test.yaml
@@ -197,8 +197,36 @@ tests:
                   path: elasticsearch_custom.yml
       - isEmpty:
           path: spec.template.spec.nodeSelector
-      - isEmpty:
+      - equal:
           path: spec.template.spec.affinity
+          value:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: app.kubernetes.io/name
+                      operator: In
+                      values:
+                      - elasticsearch
+                    - key: app.kubernetes.io/component
+                      operator: In
+                      values:
+                      - data
+                  topologyKey: failure-domain.beta.kubernetes.io/zone
+                weight: 100
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                    - elasticsearch
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                    - data
+                topologyKey: kubernetes.io/hostname
       - isEmpty:
           path: spec.template.spec.tolerations
       - isNull:
@@ -243,11 +271,6 @@ tests:
       - equal:
           path: spec.updateStrategy.type
           value: RollingUpdate
-      - equal:
-          path: spec.updateStrategy.rollingUpdate
-          value:
-            maxUnavailable: 0
-            maxSurge: 1
 
   - it: can set priority class name
     set:

--- a/stable/elasticsearch/tests/master-statefulset_test.yaml
+++ b/stable/elasticsearch/tests/master-statefulset_test.yaml
@@ -25,9 +25,6 @@ tests:
           path: spec.updateStrategy
           value:
             type: RollingUpdate
-            rollingUpdate:
-              maxSurge: 1
-              maxUnavailable: 0
       - equal:
           path: spec.selector
           value:
@@ -198,8 +195,36 @@ tests:
                   path: elasticsearch_custom.yml
       - isEmpty:
           path: spec.template.spec.nodeSelector
-      - isEmpty:
+      - equal:
           path: spec.template.spec.affinity
+          value:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: app.kubernetes.io/name
+                      operator: In
+                      values:
+                      - elasticsearch
+                    - key: app.kubernetes.io/component
+                      operator: In
+                      values:
+                      - master
+                  topologyKey: failure-domain.beta.kubernetes.io/zone
+                weight: 100
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                    - elasticsearch
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                    - master
+                topologyKey: kubernetes.io/hostname
       - isEmpty:
           path: spec.template.spec.tolerations
       - isNull:


### PR DESCRIPTION
Define a default affinity of keeping pods of the same component on separate nodes. Prefer pods to be in different availability zones.

Also remove rolling update strategy settings for statefulset as this is only valid for deployments.