### PR TITLE
[stable/elasticsearch] Set cluster name in deployment and statefulsets

### DIFF
--- a/stable/elasticsearch/Chart.yaml
+++ b/stable/elasticsearch/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "6.5.1"
 description: A Helm chart for Elasticsearch
 name: elasticsearch
 icon: https://www.elastic.co/static/images/elastic-logo-200.png
-version: 1.1.2
+version: 1.1.3
 maintainers:
   - name: Fairfax Media Operations
     email: github@fairfaxmedia.com.au

--- a/stable/elasticsearch/templates/client-deploy.yaml
+++ b/stable/elasticsearch/templates/client-deploy.yaml
@@ -60,6 +60,11 @@ spec:
                 - IPC_LOCK
                 - SYS_RESOURCE
           env:
+            - name: ES_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "elasticsearch.fullname" . }}
+                  key: es.cluster.name
             - name: ES_NODE_NAME
               value: ${HOSTNAME}
             - name: ES_RAM_PERCENTAGE

--- a/stable/elasticsearch/templates/data-statefulset.yaml
+++ b/stable/elasticsearch/templates/data-statefulset.yaml
@@ -57,6 +57,11 @@ spec:
                 - IPC_LOCK
                 - SYS_RESOURCE
           env:
+            - name: ES_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "elasticsearch.fullname" . }}
+                  key: es.cluster.name
             - name: ES_NODE_NAME
               value: ${HOSTNAME}
             - name: ES_NODE_DATA

--- a/stable/elasticsearch/templates/master-statefulset.yaml
+++ b/stable/elasticsearch/templates/master-statefulset.yaml
@@ -57,6 +57,11 @@ spec:
                 - IPC_LOCK
                 - SYS_RESOURCE
           env:
+            - name: ES_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "elasticsearch.fullname" . }}
+                  key: es.cluster.name
             - name: ES_NODE_NAME
               value: ${HOSTNAME}
             - name: ES_NODE_MASTER

--- a/stable/elasticsearch/tests/__snapshot__/client-deploy_test.yaml.snap
+++ b/stable/elasticsearch/tests/__snapshot__/client-deploy_test.yaml.snap
@@ -49,6 +49,11 @@ has defaults:
               topologyKey: kubernetes.io/hostname
         containers:
         - env:
+          - name: ES_CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                key: es.cluster.name
+                name: RELEASE-NAME-elasticsearch
           - name: ES_NODE_NAME
             value: ${HOSTNAME}
           - name: ES_RAM_PERCENTAGE

--- a/stable/elasticsearch/tests/__snapshot__/data-statefulset_test.yaml.snap
+++ b/stable/elasticsearch/tests/__snapshot__/data-statefulset_test.yaml.snap
@@ -46,6 +46,11 @@ has defaults:
               topologyKey: kubernetes.io/hostname
         containers:
         - env:
+          - name: ES_CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                key: es.cluster.name
+                name: RELEASE-NAME-elasticsearch
           - name: ES_NODE_NAME
             value: ${HOSTNAME}
           - name: ES_NODE_DATA

--- a/stable/elasticsearch/tests/__snapshot__/master-statefulset_test.yaml.snap
+++ b/stable/elasticsearch/tests/__snapshot__/master-statefulset_test.yaml.snap
@@ -46,6 +46,11 @@ has defaults:
               topologyKey: kubernetes.io/hostname
         containers:
         - env:
+          - name: ES_CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                key: es.cluster.name
+                name: RELEASE-NAME-elasticsearch
           - name: ES_NODE_NAME
             value: ${HOSTNAME}
           - name: ES_NODE_MASTER

--- a/stable/elasticsearch/tests/client-deploy_test.yaml
+++ b/stable/elasticsearch/tests/client-deploy_test.yaml
@@ -64,6 +64,14 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
+            name: ES_CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                key: es.cluster.name
+                name: RELEASE-NAME-elasticsearch
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
             name: ES_NODE_NAME
             value: ${HOSTNAME}
       - contains:

--- a/stable/elasticsearch/tests/data-statefulset_test.yaml
+++ b/stable/elasticsearch/tests/data-statefulset_test.yaml
@@ -71,6 +71,14 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
+            name: ES_CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                key: es.cluster.name
+                name: RELEASE-NAME-elasticsearch
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
             name: ES_NODE_NAME
             value: ${HOSTNAME}
       - contains:

--- a/stable/elasticsearch/tests/master-statefulset_test.yaml
+++ b/stable/elasticsearch/tests/master-statefulset_test.yaml
@@ -69,6 +69,14 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
+            name: ES_CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                key: es.cluster.name
+                name: RELEASE-NAME-elasticsearch
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
             name: ES_NODE_NAME
             value: ${HOSTNAME}
       - contains:


### PR DESCRIPTION
Cluster name variable was not set in the deployment and statefulset resources.