### PR TITLE
[stable/elasticsearch] Set cpu requests for nodes

### DIFF
--- a/stable/elasticsearch/Chart.yaml
+++ b/stable/elasticsearch/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "6.5.1"
 description: A Helm chart for Elasticsearch
 name: elasticsearch
 icon: https://www.elastic.co/static/images/elastic-logo-200.png
-version: 1.2.0
+version: 1.2.1
 maintainers:
   - name: Fairfax Media Operations
     email: github@fairfaxmedia.com.au

--- a/stable/elasticsearch/tests/__snapshot__/client-deploy_test.yaml.snap
+++ b/stable/elasticsearch/tests/__snapshot__/client-deploy_test.yaml.snap
@@ -113,6 +113,7 @@ has defaults:
             limits:
               memory: 658Mi
             requests:
+              cpu: 250m
               memory: 658Mi
           securityContext:
             capabilities:

--- a/stable/elasticsearch/tests/__snapshot__/data-statefulset_test.yaml.snap
+++ b/stable/elasticsearch/tests/__snapshot__/data-statefulset_test.yaml.snap
@@ -112,6 +112,7 @@ has defaults:
             limits:
               memory: 658Mi
             requests:
+              cpu: 250m
               memory: 658Mi
           securityContext:
             capabilities:

--- a/stable/elasticsearch/tests/__snapshot__/master-statefulset_test.yaml.snap
+++ b/stable/elasticsearch/tests/__snapshot__/master-statefulset_test.yaml.snap
@@ -112,6 +112,7 @@ has defaults:
             limits:
               memory: 512Mi
             requests:
+              cpu: 250m
               memory: 512Mi
           securityContext:
             capabilities:

--- a/stable/elasticsearch/tests/client-deploy_test.yaml
+++ b/stable/elasticsearch/tests/client-deploy_test.yaml
@@ -129,6 +129,7 @@ tests:
           path: spec.template.spec.containers[0].resources
           value:
             requests:
+              cpu: 250m
               memory: 658Mi
             limits:
               memory: 658Mi

--- a/stable/elasticsearch/tests/data-statefulset_test.yaml
+++ b/stable/elasticsearch/tests/data-statefulset_test.yaml
@@ -186,6 +186,7 @@ tests:
           path: spec.template.spec.containers[0].resources
           value:
             requests:
+              cpu: 250m
               memory: 658Mi
             limits:
               memory: 658Mi

--- a/stable/elasticsearch/tests/master-statefulset_test.yaml
+++ b/stable/elasticsearch/tests/master-statefulset_test.yaml
@@ -184,6 +184,7 @@ tests:
           path: spec.template.spec.containers[0].resources
           value:
             requests:
+              cpu: 250m
               memory: 512Mi
             limits:
               memory: 512Mi

--- a/stable/elasticsearch/values.yaml
+++ b/stable/elasticsearch/values.yaml
@@ -46,6 +46,7 @@ master:
   strategyType: RollingUpdate
   resources:
     requests:
+      cpu: 250m
       memory: 512Mi
     limits:
       memory: 512Mi
@@ -60,6 +61,7 @@ data:
   strategyType: OnDelete
   resources:
     requests:
+      cpu: 250m
       memory: 658Mi
     limits:
       memory: 658Mi
@@ -77,6 +79,7 @@ client:
   strategyType: RollingUpdate
   resources:
     requests:
+      cpu: 250m
       memory: 658Mi
     limits:
       memory: 658Mi


### PR DESCRIPTION
Set the default cpu requests for nodes. A cpu request of 250m allows the container to start before the initialDelaySeconds (300) + liveliness probe (10 * 3) timer is triggered. This gives 5:30 for a container to start before it is killed.