### PR TITLE
Make WebUI available on a dedicated port

### DIFF
--- a/stable/zalenium/Chart.yaml
+++ b/stable/zalenium/Chart.yaml
@@ -1,5 +1,5 @@
 name: zalenium
-version: 0.0.2
+version: 0.0.3
 appVersion: 3.141.59
 description: Chart for deploying Zalenium
 sources:

--- a/stable/zalenium/templates/service.yaml
+++ b/stable/zalenium/templates/service.yaml
@@ -16,8 +16,9 @@ spec:
   sessionAffinity: {{ .Values.hub.serviceSessionAffinity | quote }}
   ports:
   - name: hub
-    port: {{ .Values.hub.port }}
+    port: {{ .Values.hub.svcPort }}
     targetPort: {{ .Values.hub.port }}
   selector:
     app.kubernetes.io/name: {{ include "zalenium.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    

--- a/stable/zalenium/values.yaml
+++ b/stable/zalenium/values.yaml
@@ -50,10 +50,15 @@ hub:
   # serviceType: "NodePort"
   serviceType: "LoadBalancer"
 
+  ## Port on which K8s service is listening on. Zalenium WebUI will be available there.
+  svcPort: 80
+
   serviceAnnotations:
     service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "tcp"
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+    ## to create a route53 record please uncomment the line below
+    # dns.alpha.kubernetes.io/external: "myzalenium.companyname.com"
 
   ## If serviceType is LoadBalancer:
   ##   Add list of IPs allowed to connect to the service


### PR DESCRIPTION
By default WebUI is available on the same port as the container was listening on - `4444`. 
This is not convenient and causes issues when some traffic filtering is in place.