### PR TITLE
 Added annotations feature.

### DIFF
--- a/stable/confidant/Chart.yaml
+++ b/stable/confidant/Chart.yaml
@@ -2,8 +2,7 @@ apiVersion: v1
 description: A Helm chart for Confidant (github.com/lyft/confidant)
 name: confidant
 icon: https://github.com/lyft/confidant/raw/gh-pages/images/safe-1d911346.png
-version: 1.1.0
+version: 1.2.0
 maintainers:
   - name: FFX Blue Operations
     email: blueops@fairfaxmedia.com.au
-

--- a/stable/confidant/templates/app-deploy.yaml
+++ b/stable/confidant/templates/app-deploy.yaml
@@ -23,6 +23,9 @@ spec:
       annotations:
         checksum/secret: {{ include (print $.Chart.Name "/templates/" "app-secret.yaml") . | sha256sum }}
         checksum/secretCerts: {{ include (print $.Chart.Name "/templates/" "app-certificates-secret.yaml") . | sha256sum }}
+      {{- if .Values.annotations }}
+{{ toYaml .Values.annotations | indent 8 }}
+      {{- end }}
     spec:
       containers:
         - name: {{ .Chart.Name }}


### PR DESCRIPTION
This will make the deployment more flexible and particularly prepare confidant chart to be used with `kiam`.

Tested with:
`helm template -f helm/values.yaml ../fairfax-charts/stable/confidant`

As a result got annotations from the `values.yaml` in the deployment template.