### PR TITLE
added flag to enable/disable saml role support

### DIFF
--- a/stable/confidant/Chart.yaml
+++ b/stable/confidant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart for Confidant (github.com/lyft/confidant)
 name: confidant
 icon: https://github.com/lyft/confidant/raw/gh-pages/images/safe-1d911346.png
-version: 1.2.0
+version: 1.3.0
 maintainers:
   - name: FFX Blue Operations
     email: blueops@fairfaxmedia.com.au

--- a/stable/confidant/README.md
+++ b/stable/confidant/README.md
@@ -29,6 +29,7 @@ For <http://github.com/lyft/confidant>
 | `saml.spKey`                            | `-----BEGIN PRIVATE KEY-----`                                       | ..          |
 | `saml.spKeyFilePassword`                | `putTheSpKeyPasswordHere`                                           | ..          |
 | `saml.idpCert`                          | `-----BEGIN CERTIFICATE-----`                                       | ..          |
+| `saml.enableSecurityRoles`              | `false`                                                             | ..          |
 | `confidant.debug`                       | `true`                                                              | ..          |
 | `confidant.dynamodbTable`               | `confidant-data`                                                    | ..          |
 | `confidant.createDynamodbTable`         | `true`                                                              | ..          |

--- a/stable/confidant/templates/app-deploy.yaml
+++ b/stable/confidant/templates/app-deploy.yaml
@@ -122,6 +122,8 @@ spec:
               value: {{ .Values.saml.idpEntityId | quote }}
             - name: SAML_IDP_LOGOUT_URL
               value: {{ .Values.saml.idpLogoutUrl | quote }}
+            - name: SAML_USE_ROLE
+              value: {{ .Values.saml.enableSecurityRoles | quote }}
 {{ end }}
           ports:
             - name: http

--- a/stable/confidant/values.yaml
+++ b/stable/confidant/values.yaml
@@ -18,6 +18,7 @@ service:
 authModule: "saml"
 
 saml:
+  enableSecurityRoles: "false"
   confidantUrlRoot: "https://confidant.example.com/"
   securitySloRespSigned: "false"
   securityMessagesSigned: "false"


### PR DESCRIPTION
Added a flag to allow SAML role support via an environment variable. Currently, role support is available with the following docker image `fairfaxmedia/confidant:4.4.0-roles` we might consider updating to use your own Dockerfile in this chart.