### PR TITLE
Highlight that annotations are available

### DIFF
--- a/stable/confidant/Chart.yaml
+++ b/stable/confidant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart for Confidant (github.com/lyft/confidant)
 name: confidant
 icon: https://github.com/lyft/confidant/raw/gh-pages/images/safe-1d911346.png
-version: 1.3.0
+version: 1.3.1
 maintainers:
   - name: FFX Blue Operations
     email: blueops@fairfaxmedia.com.au

--- a/stable/confidant/README.md
+++ b/stable/confidant/README.md
@@ -46,3 +46,4 @@ For <http://github.com/lyft/confidant>
 | `confidant.sessionSecret`               | `someuniquestringheretomakethingssafer`                             | ..          |
 | `confidant.forwardedAllowIps`           | `*`                                                                 | ..          |
 | `secretupdater.enable`                  | `false`                                                             | ..          |
+| `annotations`                           | ``                                                                  | ..          |

--- a/stable/confidant/README.md
+++ b/stable/confidant/README.md
@@ -46,4 +46,4 @@ For <http://github.com/lyft/confidant>
 | `confidant.sessionSecret`               | `someuniquestringheretomakethingssafer`                             | ..          |
 | `confidant.forwardedAllowIps`           | `*`                                                                 | ..          |
 | `secretupdater.enable`                  | `false`                                                             | ..          |
-| `annotations`                           | ``                                                                  | ..          |
+| `annotations`                           | `{}`                                                                | ..          |

--- a/stable/confidant/values.yaml
+++ b/stable/confidant/values.yaml
@@ -66,3 +66,5 @@ deploy:
     nodeAffinity: {}
   tolerations: {}
   resources: {}
+
+annotations: {}


### PR DESCRIPTION
Highlight that annotations can be placed into the deployment and onto the pods.  
This is often useful for kiam or kube2iam, to access AWS IAM roles.