### PR TITLE
[elasticsearch] Checksum annotations needs to be within the template key

### DIFF
--- a/stable/elasticsearch/Chart.yaml
+++ b/stable/elasticsearch/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "6.5.1"
 description: A Helm chart for Elasticsearch
 name: elasticsearch
 icon: https://www.elastic.co/static/images/elastic-logo-200.png
-version: 1.2.3
+version: 1.2.4
 maintainers:
   - name: Fairfax Media Operations
     email: github@fairfaxmedia.com.au

--- a/stable/elasticsearch/templates/client-deploy.yaml
+++ b/stable/elasticsearch/templates/client-deploy.yaml
@@ -8,8 +8,6 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/component: client
-  annotations:
-    checksum/config: {{ include (print $.Template.BasePath "/common-cm.yaml") . | sha256sum }}
 spec:
   replicas: {{ .Values.client.replicaCount }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit | default "5" }}
@@ -27,8 +25,9 @@ spec:
       app.kubernetes.io/component: client
   template:
     metadata:
-{{- if .Values.client.annotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/common-cm.yaml") . | sha256sum }}
+{{- if .Values.client.annotations }}
 {{ toYaml .Values.client.annotations | indent 8 }}
 {{- end }}
       labels:

--- a/stable/elasticsearch/templates/data-statefulset.yaml
+++ b/stable/elasticsearch/templates/data-statefulset.yaml
@@ -8,8 +8,6 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/component: data
-  annotations:
-    checksum/config: {{ include (print $.Template.BasePath "/common-cm.yaml") . | sha256sum }}
 spec:
   serviceName: {{ include "elasticsearch.fullname" . }}
   replicas: {{ .Values.data.replicaCount }}
@@ -24,8 +22,9 @@ spec:
       app.kubernetes.io/component: data
   template:
     metadata:
-{{- if .Values.data.annotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/common-cm.yaml") . | sha256sum }}
+{{- if .Values.data.annotations }}
 {{ toYaml .Values.data.annotations | indent 8 }}
 {{- end }}
       labels:

--- a/stable/elasticsearch/templates/master-statefulset.yaml
+++ b/stable/elasticsearch/templates/master-statefulset.yaml
@@ -8,8 +8,6 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/component: master
-  annotations:
-    checksum/config: {{ include (print $.Template.BasePath "/common-cm.yaml") . | sha256sum }}
 spec:
   serviceName: {{ include "elasticsearch.fullname" . }}
   replicas: {{ .Values.master.replicaCount }}
@@ -24,8 +22,9 @@ spec:
       app.kubernetes.io/component: master
   template:
     metadata:
-{{- if .Values.master.annotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/common-cm.yaml") . | sha256sum }}
+{{- if .Values.master.annotations }}
 {{ toYaml .Values.master.annotations | indent 8 }}
 {{- end }}
       labels:


### PR DESCRIPTION
Checksum annotations needs to be within the template key otherwise they won't trigger pod replacement.