### PR TITLE
add sp key file password value to chart

### DIFF
--- a/stable/confidant/Chart.yaml
+++ b/stable/confidant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart for Confidant (github.com/lyft/confidant)
 name: confidant
 icon: https://github.com/lyft/confidant/raw/gh-pages/images/safe-1d911346.png
-version: 1.4.1
+version: 1.4.2
 maintainers:
   - name: FFX Blue Operations
     email: blueops@fairfaxmedia.com.au

--- a/stable/confidant/README.md
+++ b/stable/confidant/README.md
@@ -27,7 +27,7 @@ For <http://github.com/lyft/confidant>
 | `saml.idpLogoutUrl`                     | `https://example.onelogin.com/trust/saml2/http-redirect/slo/000000` | ..          |
 | `saml.spCert`                           | ..                                                                  | ..          |
 | `saml.spKey`                            | `-----BEGIN PRIVATE KEY-----`                                       | ..          |
-| `saml.spKeyFilePassword`                | `putTheSpKeyPasswordHere`                                           | ..          |
+| `saml.spKeyFilePassword`                | `""`                                                                | ..          |
 | `saml.idpCert`                          | `-----BEGIN CERTIFICATE-----`                                       | ..          |
 | `confidant.enableSecurityRoles`         | `false`                                                             | Can ONLY be used with the fairfaxmedia/confidant:4.4.0-roles docker image. Currently only SAML auth type is supported, future releases may support other auth types |
 | `confidant.roleAdmin`                   | `admin`                                                             | Role that's allowed full Admin access |

--- a/stable/confidant/templates/app-deploy.yaml
+++ b/stable/confidant/templates/app-deploy.yaml
@@ -135,6 +135,10 @@ spec:
             - name: SAML_IDP_LOGOUT_URL
               value: {{ .Values.saml.idpLogoutUrl | quote }}
 {{ end }}
+{{ if .Values.saml.spKeyFilePassword }}
+            - name: SAML_SP_KEY_FILE_PASSWORD
+              value: {{ .Values.saml.spKeyFilePassword | quote }}
+{{ end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.containerPort }}

--- a/stable/confidant/values.yaml
+++ b/stable/confidant/values.yaml
@@ -33,7 +33,7 @@ saml:
     -----BEGIN PRIVATE KEY-----
     PUT_YOUR_KEY_HERE
     -----END PRIVATE KEY-----
-  spKeyFilePassword: "putTheSpKeyPasswordHere"
+  spKeyFilePassword: ""
   idpCert: |
     -----BEGIN CERTIFICATE-----
     PUT_IDENTITY_PROVIDER_CERT_HERE


### PR DESCRIPTION
If value `saml.spKeyFilePassword` is not an empty string add environment
value SAML_SP_KEY_FILE_PASSWORD to use with SAML_SP_KEY_FILE