### PR TITLE
✨[stable/simple-pdb] add simple chart for pod disruption budgets

### DIFF
--- a/stable/simple-pdb/Chart.yaml
+++ b/stable/simple-pdb/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: simple-pdb
+version: 0.1.0

--- a/stable/simple-pdb/README.md
+++ b/stable/simple-pdb/README.md
@@ -1,0 +1,10 @@
+# Simple PDB
+
+This chart just installs a Pod Disruption Budget.
+
+## Use case
+
+If you need to add a PDB to an app installed by a third-party chart,
+and you cannot (or don't want to) edit that chart, install the PDB with this chart.
+
+You will need to ensure it goes into the same namespace so the PDB can find the pods.

--- a/stable/simple-pdb/templates/NOTES.txt
+++ b/stable/simple-pdb/templates/NOTES.txt
@@ -1,0 +1,1 @@
+This page intentionally left blank.

--- a/stable/simple-pdb/templates/_helpers.tpl
+++ b/stable/simple-pdb/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "simple-pdb.name" -}}
+{{- default .Chart.Name .Values.simplePDB.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "simple-pdb.fullname" -}}
+{{- $name := default .Chart.Name .Values.simplePDB.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/simple-pdb/templates/pdb.yaml
+++ b/stable/simple-pdb/templates/pdb.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.simplePDB.enabled -}}
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "simple-pdb.fullname" . }}
+  labels:
+    app: {{ template "simple-pdb.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+spec:
+{{- if .Values.simplePDB.minAvailable }}
+  minAvailable: {{ .Values.simplePDB.minAvailable }}
+{{- end }}
+{{- if .Values.simplePDB.maxUnavailable }}
+  maxUnavailable: {{ .Values.simplePDB.maxUnavailable }}
+{{- end }}
+  selector:
+    matchLabels:
+      app: {{ .Values.simplePDB.app }}
+{{- end }}

--- a/stable/simple-pdb/values.yaml
+++ b/stable/simple-pdb/values.yaml
@@ -1,0 +1,7 @@
+# Default values for simple-ingress.
+
+simplePDB:
+  enabled: true
+  app: app
+  minAvailable: 1
+  # maxUnavailable: 1


### PR DESCRIPTION
This addresses the need where an app just needs a Pod Disruption Budget added, and you are unwilling to implement using an upstream app chart.

Signed-off-by: Frode Egeland <frode.egeland@fairfaxmedia.com.au>