### PR TITLE
[opentelemetrycollector] Check cluster capabilities for CRD

### DIFF
--- a/stable/opentelemetrycollector/Chart.yaml
+++ b/stable/opentelemetrycollector/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 0.5.0
 description: opentelemetrycollector Helm chart for Kubernetes
 name: opentelemetrycollector
-version: 0.1.0
+version: 0.1.1

--- a/stable/opentelemetrycollector/templates/opentelemetrycollector.yaml
+++ b/stable/opentelemetrycollector/templates/opentelemetrycollector.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "opentelemetry.io/v1alpha1" }}
 apiVersion: opentelemetry.io/v1alpha1
 kind: OpenTelemetryCollector
 metadata:
@@ -43,3 +44,4 @@ spec:
   - {{ . | quote }}
   {{- end }}
   {{- end }}
+{{- end }}


### PR DESCRIPTION
Check cluster capabilities for CRD. If does not exist this will do nothing which is a better outcome than failing. Mostly allows a diff to run before anything is installed.