### PR TITLE
[opentelemetrycollector] Upgrade collector version

### DIFF
--- a/stable/opentelemetrycollector/Chart.yaml
+++ b/stable/opentelemetrycollector/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.5.0
+appVersion: 0.7.0
 description: opentelemetrycollector Helm chart for Kubernetes
 name: opentelemetrycollector
-version: 0.1.1
+version: 0.2.0


### PR DESCRIPTION
Upgrade the OpenTelemetry collector to version 0.7.0. No values need to be changed for the image tag, only the chart app version because of this line in the template:
```
{{ default .Chart.AppVersion .Values.image.tag }}
```
