### PR TITLE
[stable/varnish] bring chart up to date with internal version, making it k8s 1.18+ compatible

### DIFF
--- a/stable/varnish/Chart.yaml
+++ b/stable/varnish/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for varnish
 name: varnish
-version: 3.3.0
+version: 4.0.0
 icon: https://www.varnish-software.com/wp-content/uploads/320x200.png
 maintainers:
   - name: FFX Blue Operations

--- a/stable/varnish/Makefile
+++ b/stable/varnish/Makefile
@@ -1,0 +1,9 @@
+snapshot:
+	rm -f tests/__snapshot__/*
+	make test
+
+test:
+	helm unittest .
+
+# None of the Make tasks generate files with the name of the task, so all must be declared as 'PHONY'
+.PHONY: snapshot test

--- a/stable/varnish/templates/deployment.yaml
+++ b/stable/varnish/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- $root := . }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -11,6 +11,9 @@ metadata:
     release: {{ .Release.Name | quote }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
   minReadySeconds: 15
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   strategy:

--- a/stable/varnish/templates/ingress.yaml
+++ b/stable/varnish/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- $root := . -}}
 {{- range $key, $value := .Values.ingress }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "fullname" $root }}-{{ $key }}
@@ -24,7 +24,7 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: {{ template "fullname" $root }}
+          serviceName: {{ template "service.name" $root }}
           servicePort: {{ $root.Values.service.externalPort }}
         path: {{ default "/" $value.path }}
 ...

--- a/stable/varnish/tests/__snapshot__/ingress_test.yaml.snap
+++ b/stable/varnish/tests/__snapshot__/ingress_test.yaml.snap
@@ -1,0 +1,66 @@
+has ingress by default:
+  1: |
+    apiVersion: networking.k8s.io/v1beta1
+    kind: Ingress
+    metadata:
+      labels:
+        app: RELEASE-NAME-varnish
+        chart: varnish-4.0.0
+        component: proxy
+        heritage: Tiller
+        name: external
+        release: RELEASE-NAME
+      name: RELEASE-NAME-varnish-external
+    spec:
+      rules:
+      - host: dummy-varnish.example.com
+        http:
+          paths:
+          - backend:
+              serviceName: RELEASE-NAME-varnish
+              servicePort: 80
+            path: /
+matches the snapshot with one ingress:
+  1: |
+    apiVersion: networking.k8s.io/v1beta1
+    kind: Ingress
+    metadata:
+      labels:
+        app: RELEASE-NAME-varnish
+        chart: varnish-4.0.0
+        component: proxy
+        heritage: Tiller
+        name: external
+        release: RELEASE-NAME
+      name: RELEASE-NAME-varnish-external
+    spec:
+      rules:
+      - host: dummy-varnish.example.com
+        http:
+          paths:
+          - backend:
+              serviceName: RELEASE-NAME-varnish
+              servicePort: 80
+            path: /
+uses correct service with service nameOverride applied:
+  1: |
+    apiVersion: networking.k8s.io/v1beta1
+    kind: Ingress
+    metadata:
+      labels:
+        app: RELEASE-NAME-varnish
+        chart: varnish-4.0.0
+        component: proxy
+        heritage: Tiller
+        name: external
+        release: RELEASE-NAME
+      name: RELEASE-NAME-varnish-external
+    spec:
+      rules:
+      - host: dummy-varnish.example.com
+        http:
+          paths:
+          - backend:
+              serviceName: proxy
+              servicePort: 80
+            path: /

--- a/stable/varnish/tests/ingress_test.yaml
+++ b/stable/varnish/tests/ingress_test.yaml
@@ -1,0 +1,43 @@
+suite: Test ingress
+templates:
+  - ingress.yaml
+tests:
+  - it: has ingress by default
+    asserts:
+      - hasDocuments: { count: 1 }
+      - matchSnapshot: {}
+      - isKind:
+          of: Ingress
+
+  - it: matches the snapshot with one ingress
+    values:
+      - ./values/ok.yaml
+    asserts:
+      - hasDocuments: { count: 1 }
+      - matchSnapshot: {}
+      - isKind:
+          of: Ingress
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-varnish-external
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.serviceName
+          value: RELEASE-NAME-varnish
+
+  - it: uses correct service with service nameOverride applied
+    values:
+    - ./values/ok.yaml
+    set:
+      service:
+        nameOverride: proxy
+    asserts:
+    - hasDocuments: { count: 1 }
+    - matchSnapshot: {}
+    - isKind:
+        of: Ingress
+    - equal:
+        path: metadata.name
+        value: RELEASE-NAME-varnish-external
+    - equal:
+        path: spec.rules[0].http.paths[0].backend.serviceName
+        value: proxy

--- a/stable/varnish/tests/values/ok.yaml
+++ b/stable/varnish/tests/values/ok.yaml
@@ -1,0 +1,6 @@
+service:
+  externalPort: 80
+  annotations:
+    prometheus.io/path: "/metrics"
+    prometheus.io/port: "9131"
+    prometheus.io/scrape: "true"


### PR DESCRIPTION


Signed-off-by: Frode Egeland <frode.egeland@fairfaxmedia.com.au>