### PR TITLE
[elasticsearch] Fix failing unit tests

### DIFF
--- a/stable/elasticsearch/tests/__snapshot__/client-deploy_test.yaml.snap
+++ b/stable/elasticsearch/tests/__snapshot__/client-deploy_test.yaml.snap
@@ -14,6 +14,8 @@ has defaults:
       type: RollingUpdate
     template:
       metadata:
+        annotations:
+          checksum/config: bc51dd1d3da33408bcadb1094cbbde7210a4dd7f7d5cf84408ba15a1faa50773
         labels:
           app.kubernetes.io/component: client
           app.kubernetes.io/instance: RELEASE-NAME
@@ -83,7 +85,7 @@ has defaults:
               configMapKeyRef:
                 key: es.gateway.recover_after_time
                 name: RELEASE-NAME-elasticsearch
-          image: fairfaxmedia/elasticsearch:v1.0.4-elasticsearch6.5.1
+          image: fairfaxmedia/elasticsearch:v1.0.5-elasticsearch6.5.1
           imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:

--- a/stable/elasticsearch/tests/__snapshot__/data-statefulset_test.yaml.snap
+++ b/stable/elasticsearch/tests/__snapshot__/data-statefulset_test.yaml.snap
@@ -11,6 +11,8 @@ has defaults:
     serviceName: RELEASE-NAME-elasticsearch
     template:
       metadata:
+        annotations:
+          checksum/config: bc51dd1d3da33408bcadb1094cbbde7210a4dd7f7d5cf84408ba15a1faa50773
         labels:
           app.kubernetes.io/component: data
           app.kubernetes.io/instance: RELEASE-NAME
@@ -82,7 +84,7 @@ has defaults:
               configMapKeyRef:
                 key: es.gateway.recover_after_time
                 name: RELEASE-NAME-elasticsearch
-          image: fairfaxmedia/elasticsearch:v1.0.4-elasticsearch6.5.1
+          image: fairfaxmedia/elasticsearch:v1.0.5-elasticsearch6.5.1
           imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:

--- a/stable/elasticsearch/tests/__snapshot__/master-statefulset_test.yaml.snap
+++ b/stable/elasticsearch/tests/__snapshot__/master-statefulset_test.yaml.snap
@@ -11,6 +11,8 @@ has defaults:
     serviceName: RELEASE-NAME-elasticsearch
     template:
       metadata:
+        annotations:
+          checksum/config: bc51dd1d3da33408bcadb1094cbbde7210a4dd7f7d5cf84408ba15a1faa50773
         labels:
           app.kubernetes.io/component: master
           app.kubernetes.io/instance: RELEASE-NAME
@@ -82,7 +84,7 @@ has defaults:
               configMapKeyRef:
                 key: es.gateway.recover_after_time
                 name: RELEASE-NAME-elasticsearch
-          image: fairfaxmedia/elasticsearch:v1.0.4-elasticsearch6.5.1
+          image: fairfaxmedia/elasticsearch:v1.0.5-elasticsearch6.5.1
           imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:

--- a/stable/elasticsearch/tests/client-deploy_test.yaml
+++ b/stable/elasticsearch/tests/client-deploy_test.yaml
@@ -32,6 +32,8 @@ tests:
       - equal:
           path: spec.template.metadata
           value:
+            annotations:
+              checksum/config: bc51dd1d3da33408bcadb1094cbbde7210a4dd7f7d5cf84408ba15a1faa50773
             labels:
               app.kubernetes.io/name: elasticsearch
               app.kubernetes.io/instance: RELEASE-NAME

--- a/stable/elasticsearch/tests/data-statefulset_test.yaml
+++ b/stable/elasticsearch/tests/data-statefulset_test.yaml
@@ -37,6 +37,8 @@ tests:
       - equal:
           path: spec.template.metadata
           value:
+            annotations:
+              checksum/config: bc51dd1d3da33408bcadb1094cbbde7210a4dd7f7d5cf84408ba15a1faa50773
             labels:
               app.kubernetes.io/name: elasticsearch
               app.kubernetes.io/instance: RELEASE-NAME

--- a/stable/elasticsearch/tests/master-statefulset_test.yaml
+++ b/stable/elasticsearch/tests/master-statefulset_test.yaml
@@ -35,6 +35,8 @@ tests:
       - equal:
           path: spec.template.metadata
           value:
+            annotations:
+              checksum/config: bc51dd1d3da33408bcadb1094cbbde7210a4dd7f7d5cf84408ba15a1faa50773
             labels:
               app.kubernetes.io/name: elasticsearch
               app.kubernetes.io/instance: RELEASE-NAME

--- a/stable/elasticsearch/tests/master-storageclass_test.yaml
+++ b/stable/elasticsearch/tests/master-storageclass_test.yaml
@@ -35,8 +35,8 @@ tests:
     set:
       persistence.enabled: true
       persistence.reclaimPolicy: Delete
-      persistence.data.provisioner: kubernetes.io/aws-ebs
-      persistence.data.provisionerType: gp2
+      persistence.master.provisioner: kubernetes.io/aws-ebs
+      persistence.master.provisionerType: gp2
     asserts:
       - equal:
           path: reclaimPolicy


### PR DESCRIPTION
Unit tests were failing due to the additional config checksum not being checked.

Persistence for master nodes was checked against data nodes which was also causing failing checks.

Snapshot updated to include latest image.
