### PR TITLE
[elasticsearch] Invalid conditional syntax

### DIFF
--- a/stable/elasticsearch/Chart.yaml
+++ b/stable/elasticsearch/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "6.5.1"
 description: A Helm chart for Elasticsearch
 name: elasticsearch
 icon: https://www.elastic.co/static/images/elastic-logo-200.png
-version: 1.2.4
+version: 1.2.5
 maintainers:
   - name: Fairfax Media Operations
     email: github@fairfaxmedia.com.au

--- a/stable/elasticsearch/templates/data-storageclass.yaml
+++ b/stable/elasticsearch/templates/data-storageclass.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.persistence.enabled) and (.Values.persistence.data.provisioner) }}
+{{- if and (.Values.persistence.enabled) (.Values.persistence.data.provisioner) }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:

--- a/stable/elasticsearch/templates/master-storageclass.yaml
+++ b/stable/elasticsearch/templates/master-storageclass.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.persistence.enabled) and (.Values.persistence.master.provisioner) }}
+{{- if and (.Values.persistence.enabled) (.Values.persistence.master.provisioner) }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:


### PR DESCRIPTION
Invalid use of `and` was causing failure when an updated Go version was used. This worked in previous versions due to being less strict of where `and` was located.
