### PR TITLE
[elasticsearch] client-deploy: do not set "spec.replicas" when using a Horizontal Pod Autoscaler

### DIFF
--- a/stable/elasticsearch/Chart.yaml
+++ b/stable/elasticsearch/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "6.5.1"
 description: A Helm chart for Elasticsearch
 name: elasticsearch
 icon: https://www.elastic.co/static/images/elastic-logo-200.png
-version: 1.2.5
+version: 1.2.6
 maintainers:
   - name: Fairfax Media Operations
     email: github@fairfaxmedia.com.au

--- a/stable/elasticsearch/templates/client-deploy.yaml
+++ b/stable/elasticsearch/templates/client-deploy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/component: client
 spec:
-  replicas: {{ .Values.client.replicaCount }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit | default "5" }}
   strategy:
     type: {{ .Values.client.strategyType | default "RollingUpdate" }}


### PR DESCRIPTION

It appears that when using Helm3, setting spec.replicas at the same time as using a HPA can cause a deployment to temporarily change the replica count to the value in 'spec.replicas', before changing back to the value from the HPA.

For a client deployment that has spec.replicas=3, but the replica set to 6 via HPA, it appears to scale down the deployment to three pods, then immediately back up to 6 - causing three of the six pods to be terminated and then recreated.