### PR TITLE
:bug: Valid defaults for NO_SSL and URL_PREFIX environment variables

### DIFF
--- a/stable/snappass/Chart.yaml
+++ b/stable/snappass/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "1.4.1"
+appVersion: "1.5.0"
 description: Share passwords securely
 name: snappass
-version: 0.1.0
+version: 0.1.1
 sources:
   - https://github.com/pinterest/snappass
 maintainers:

--- a/stable/snappass/README.md
+++ b/stable/snappass/README.md
@@ -61,10 +61,10 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `master.tolerations`               | `[]`                    | Array of master node tolerations                                  |
 | `secretsEnabled`                   | `true`                  | Enable managing secrets from values                               |
 | `config.secretKey`                 | `Secret Key`            | Unique key that's used to sign key                                |
-| `config.debug`                     | `false`                 | Run Flask web server in debug mode                                |
+| `config.debug`                     | `False`                 | Run Flask web server in debug mode                                |
 | `config.staticUrl`                 | `static`                | Location of static assets                                         |
-| `config.noSSL`                     | `true`                  | Disable SSL                                                       |
-| `config.urlPrefix`                 | `None`                  | Useful when running behind a reverse proxy                        |
+| `config.noSSL`                     | `True`                  | Disable SSL                                                       |
+| `config.urlPrefix`                 | ``                      | Useful when running behind a reverse proxy                        |
 | `config.redisHost`                 | `redis-headless`        | Redis host                                                        |
 | `config.redisPort`                 | `6379`                  | Redis port                                                        |
 | `config.snapPassRedisDB`           | `0`                     | Redis server database                                             |

--- a/stable/snappass/templates/configmap.yaml
+++ b/stable/snappass/templates/configmap.yaml
@@ -5,10 +5,10 @@ metadata:
   labels:
 {{ include "snappass.labels" . | indent 4 }}
 data:
-  debug: {{ .Values.config.debug | default "false" | quote }}
+  debug: {{ .Values.config.debug | default "False" | quote }}
   staticUrl: {{ .Values.config.staticUrl | default "static" | quote }}
-  noSSL: {{ .Values.config.noSSL | default "true" | quote }}
-  urlPrefix: {{ .Values.config.urlPrefix | default "true" | quote }}
+  noSSL: {{ .Values.config.noSSL | default "True" | quote }}
+  urlPrefix: {{ .Values.config.urlPrefix | default "" | quote }}
   redisHost: {{ .Values.config.redisHost | default "localhost" | quote }}
   redisPort: {{ .Values.config.redisPort | default "6379" | quote }}
   snapPassRedisDB: {{ .Values.config.snapPassRedisDB | default "0" | quote }}

--- a/stable/snappass/values.yaml
+++ b/stable/snappass/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: fairfaxmedia/snappass
-  tag: 1.4.1
+  tag: 1.5.0
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -47,10 +47,10 @@ secretsEnabled: true
 
 config:
   secretKey: Secret Key
-  debug: false
+  debug: False
   staticUrl: static
-  noSSL: true
-  urlPrefix: None
+  noSSL: True
+  urlPrefix: ""
   redisHost: redis-headless
   redisPort: 6379
   snapPassRedisDB: 0


### PR DESCRIPTION
The defaults for NO_SSL and URL_PREFIX were not set correctly and did not match the expected values.