### PR TITLE
enable serviceAccount management

### DIFF
--- a/stable/k8s-secret-updater/Chart.yaml
+++ b/stable/k8s-secret-updater/Chart.yaml
@@ -1,7 +1,8 @@
-apiVersion: v1
+apiVersion: v2
 description: A Helm chart for Kubernetes SecretUpdater
 name: k8s-secret-updater
-version: 2.0.0
+version: 2.1.0
+icon: "https://github.com/fairfaxmedia/k8s-secret-updater"
 maintainers:
   - name: Fairfax Media Operations
     email: github@fairfaxmedia.com.au

--- a/stable/k8s-secret-updater/templates/app-deploy.yaml
+++ b/stable/k8s-secret-updater/templates/app-deploy.yaml
@@ -26,6 +26,7 @@ spec:
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/app-secret.yaml") . | sha256sum }}
     spec:
+      serviceAccountName: {{ .Values.serviceAccount.name }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}

--- a/stable/k8s-secret-updater/templates/app-ingress.yaml
+++ b/stable/k8s-secret-updater/templates/app-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: {{ .Values.apiVersionOverrides.ingress }}
 kind: Ingress
 metadata:
   name: {{ .Chart.Name }}

--- a/stable/k8s-secret-updater/templates/app-service-account.yaml
+++ b/stable/k8s-secret-updater/templates/app-service-account.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    app: {{ template "fullname" . }}
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  annotations: 
+  {{- range $key, $value := .Values.serviceAccount.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }} 
+
+

--- a/stable/k8s-secret-updater/values.yaml
+++ b/stable/k8s-secret-updater/values.yaml
@@ -9,6 +9,8 @@ service:
   name: secret-updater
   containerPort: 80
   probePath: "/internal/health"
+serviceAccount:
+  create: false
 ingress:
   name: secret-updater
   containerPort: 80
@@ -27,3 +29,5 @@ confidant:
   serverAuthKey: "some_key_here"
 saml:
   confidantUrlRoot: "https://confidant.example.com/"
+apiVersionOverrides:
+  ingress: "networking.k8s.io/v1beta"


### PR DESCRIPTION
Adds the service account into the deployment which is required when this is deployed with IRSA enabled.