### PR TITLE
:recycle: added logic to service account creation

### DIFF
--- a/stable/k8s-secret-updater/Chart.yaml
+++ b/stable/k8s-secret-updater/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes SecretUpdater
 name: k8s-secret-updater
-version: 2.1.0
+version: 2.1.1
 icon: "https://github.com/fairfaxmedia/k8s-secret-updater"
 maintainers:
   - name: Fairfax Media Operations

--- a/stable/k8s-secret-updater/README.md
+++ b/stable/k8s-secret-updater/README.md
@@ -50,3 +50,11 @@ See the [k8s-secret-updater](https://github.com/fairfaxmedia/k8s-secret-updater)
 | `ingress.containerPort` | `80`                         | ..          |
 | `ingress.host`          | `secret-updater.example.com` | ..          |
 | `ingress.annotations`   | `{}`                         | ..          |
+
+### Service Account
+
+| Parameter               | Default | Description |
+| ----------------------- | ------- | ----------- |
+| `serviceAccount.create` | `false` | Create a service account with `.Chart.Name` as the name or if `serviceAccount.name`  set will use this as the name |
+| `serviceAccount.name`   | `""`    | Include a service account by its name. If `serviceAccount.create` is `true` use this name when creating the service account |
+| `serviceAccount.annotations` | `{}` | .. |

--- a/stable/k8s-secret-updater/templates/app-deploy.yaml
+++ b/stable/k8s-secret-updater/templates/app-deploy.yaml
@@ -26,7 +26,12 @@ spec:
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/app-secret.yaml") . | sha256sum }}
     spec:
+    {{- if .Values.serviceAccount.name }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
+    {{- else if .Values.serviceAccount.create }}
+      serviceAccountName: {{ .Chart.Name }}
+    {{- else }}
+    {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}

--- a/stable/k8s-secret-updater/templates/app-deploy.yaml
+++ b/stable/k8s-secret-updater/templates/app-deploy.yaml
@@ -30,7 +30,6 @@ spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
     {{- else if .Values.serviceAccount.create }}
       serviceAccountName: {{ .Chart.Name }}
-    {{- else }}
     {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/stable/k8s-secret-updater/templates/app-service-account.yaml
+++ b/stable/k8s-secret-updater/templates/app-service-account.yaml
@@ -2,7 +2,11 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+{{- if .Values.serviceAccount.name }}
+  name: {{ .Values.serviceAccount.name }}
+{{- else }}
   name: {{ .Chart.Name }}
+{{- end }}
   labels:
     app: {{ template "fullname" . }}
     heritage: {{ .Release.Service | quote }}
@@ -12,6 +16,4 @@ metadata:
   {{- range $key, $value := .Values.serviceAccount.annotations }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}
-{{- end }} 
-
-
+{{- end }}

--- a/stable/k8s-secret-updater/templates/app-service-account.yaml
+++ b/stable/k8s-secret-updater/templates/app-service-account.yaml
@@ -12,8 +12,10 @@ metadata:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+{{- if .Values.serviceAccount.annotations }}
   annotations: 
   {{- range $key, $value := .Values.serviceAccount.annotations }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Added some logic to the service account creation

Currently the default values will create an empty service account name 

```
# Source: k8s-secret-updater/templates/app-deploy.yaml
apiVersion: apps/v1
kind: Deployment
...
template:
    ...    
    spec: 
      serviceAccountName:  <- empty value here
```

This PR will not add the spec.serviceAccountName key/value if using default value `serviceAccount.create: false`

-------------------------------------------------------------------------------------

**Changes**

If `serviceAccount.create` set to `true` and no `serviceAccount.name` value present will create service account with `.Chart.name` as its name

values.yaml
```
serviceAccount:
  create: true
```

output 

```
# Source: k8s-secret-updater/templates/app-service-account.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: k8s-secret-updater
```
```
# Source: k8s-secret-updater/templates/app-deploy.yaml
apiVersion: apps/v1
kind: Deployment
...
template:
    ...    
    spec: 
      serviceAccountName: k8s-secret-updater
```

-------------------------------------------------------------------------------------

If `serviceAccount.create` set to `true` and `serviceAccount.name` value is set will create service account with `serviceAccount.name` as its name
values.yaml
```
serviceAccount:
  create: true
  name: myserviceaccount
```

output 

```
# Source: k8s-secret-updater/templates/app-service-account.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: myserviceaccount
```
```
# Source: k8s-secret-updater/templates/app-deploy.yaml
apiVersion: apps/v1
kind: Deployment
...
template:
    ...    
    spec: 
      serviceAccountName: myserviceaccount
```

-------------------------------------------------------------------------------------

If `serviceAccount.create` set to `false` and `serviceAccount.name` value is set will not create a service account but add the `serviceAccount.name` to deployments
values.yaml
```
serviceAccount:
  create: false
  name: myserviceaccount
```

output 

Source: k8s-secret-updater/templates/app-service-account.yaml not created

```
# Source: k8s-secret-updater/templates/app-deploy.yaml
apiVersion: apps/v1
kind: Deployment
...
template:
    ...    
    spec: 
      serviceAccountName: myserviceaccount
```