### PR TITLE
Upgrade/ingress api version networking k8s io v1

### DIFF
--- a/stable/k8s-secret-updater/Chart.yaml
+++ b/stable/k8s-secret-updater/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes SecretUpdater
 name: k8s-secret-updater
-version: 2.1.1
+version: 2.2.0
 icon: "https://github.com/fairfaxmedia/k8s-secret-updater"
 maintainers:
   - name: Fairfax Media Operations

--- a/stable/k8s-secret-updater/templates/app-ingress.yaml
+++ b/stable/k8s-secret-updater/templates/app-ingress.yaml
@@ -17,5 +17,7 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: {{ .Chart.Name }}
-          servicePort: {{ .Values.ingress.containerPort }}
+          service:
+            name: {{ .Chart.Name }}
+            port:
+              number: {{ .Values.ingress.containerPort }}

--- a/stable/k8s-secret-updater/templates/app-ingress.yaml
+++ b/stable/k8s-secret-updater/templates/app-ingress.yaml
@@ -7,10 +7,12 @@ metadata:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+{{- if .Values.ingress.annotations }}
   annotations:
   {{- range $key, $value := .Values.ingress.annotations }}
     {{ $key }}: {{ $value }}
   {{- end }}
+{{- end }}
 spec:
   rules:
   - host: {{ .Values.ingress.host }}

--- a/stable/k8s-secret-updater/values.yaml
+++ b/stable/k8s-secret-updater/values.yaml
@@ -30,4 +30,4 @@ confidant:
 saml:
   confidantUrlRoot: "https://confidant.example.com/"
 apiVersionOverrides:
-  ingress: "networking.k8s.io/v1beta"
+  ingress: "networking.k8s.io/v1"


### PR DESCRIPTION
- Update chart to use the version `networking.k8s.io/v1` for Ingress resource as its default value, see `apiVersionOverrides:ingress` in values.yaml
- Update Ingress Resource naming required for this API version 

`serviceName` -> `service.name`
`servicePort` -> `service.port.number`

```
service:
  name: {{ .Chart.Name }}
  port:
    number: {{ .Values.ingress.containerPort }}
```
- Only add Ingress annotations if values are set