### PR TITLE
:sparkles: [confidant] allow adding k8s service account to deployments

### DIFF
--- a/stable/confidant/Chart.yaml
+++ b/stable/confidant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart for Confidant (github.com/lyft/confidant)
 name: confidant
 icon: https://github.com/lyft/confidant/raw/gh-pages/images/safe-1d911346.png
-version: 2.1.0
+version: 2.1.1
 maintainers:
   - name: FFX Blue Operations
     email: blueops@fairfaxmedia.com.au

--- a/stable/confidant/README.md
+++ b/stable/confidant/README.md
@@ -49,4 +49,5 @@ For <http://github.com/lyft/confidant>
 | `confidant.forwardedAllowIps`           | `*`                                                                 | ..          |
 | `confidant.aclModulePath`               | `""`                                                                | See https://lyft.github.io/confidant/acls.html |
 | `secretupdater.enable`                  | `false`                                                             | ..          |
+| `serviceAccountName`                    | `""`                                                                | ..          |
 | `annotations`                           | `{}`                                                                | ..          |

--- a/stable/confidant/templates/app-deploy.yaml
+++ b/stable/confidant/templates/app-deploy.yaml
@@ -30,6 +30,9 @@ spec:
 {{ toYaml .Values.annotations | indent 8 }}
       {{- end }}
     spec:
+{{- if .Values.serviceAccountName }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
+{{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
Ability to add a service account to k8s deployments. Default is no service account / Use default one created by k8s