### PR TITLE
:sparkles: [confidant] Add securityContext to Container

### DIFF
--- a/stable/confidant/Chart.yaml
+++ b/stable/confidant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart for Confidant (github.com/lyft/confidant)
 name: confidant
 icon: https://github.com/lyft/confidant/raw/gh-pages/images/safe-1d911346.png
-version: 2.3.0
+version: 2.4.0
 maintainers:
   - name: FFX Blue Operations
     email: blueops@fairfaxmedia.com.au

--- a/stable/confidant/README.md
+++ b/stable/confidant/README.md
@@ -17,7 +17,7 @@ For <http://github.com/lyft/confidant>
 | `service.type`                          | `LoadBalancer`                                                      | ..          |
 | `service.containerPort`                 | `80`                                                                | ..          |
 | `service.probePath`                     | `/loggedout`                                                        | ..          |
-| `environment`                     	  | `{}`                                                                | Add Environment Variables |
+| `environment`                           | `{}`                                                                | Add Environment Variables |
 | `authModule`                            | `saml`                                                              | ..          |
 | `saml.confidantUrlRoot`                 | `https://confidant.example.com/`                                    | ..          |
 | `saml.securitySloRespSigned`            | `false`                                                             | ..          |
@@ -59,3 +59,8 @@ For <http://github.com/lyft/confidant>
 | `ingress.path`                          | `"/"`                                                               | ..          |
 | `ingress.pathType`                      | `"ImplementationSpecific"`                                          | ..          |
 | `ingress.host`                          | `confidant.example.com`                                             | ..          |
+| `securityContext.runAsNonRoot`             | `false`                                                          | If `true` containers must be required to run as non-root users. |
+| `securityContext.privileged`               | `false`                                                          | Run container in privileged mode. |
+| `securityContext.allowPrivilegeEscalation` | `false`                                                          | Controls whether a process can gain more privileges than its parent process. |
+| `securityContext.runAsUser`                | `10001`                                                          | The UID that the container's main process should run as. |
+| `securityContext.runAsGroup`               | `10001`                                                          | The GID that the container's main process should run as. |

--- a/stable/confidant/templates/app-deploy.yaml
+++ b/stable/confidant/templates/app-deploy.yaml
@@ -39,6 +39,14 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            privileged: {{ .Values.securityContext.privileged }}
+            allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+          {{- if eq .Values.securityContext.runAsNonRoot true }}
+            runAsUser: {{ .Values.securityContext.runAsUser }}
+            runAsGroup: {{ .Values.securityContext.runAsGroup }}
+          {{- end }}
           volumeMounts:
             - name: certificates
               mountPath: "/srv/certificates"

--- a/stable/confidant/values.yaml
+++ b/stable/confidant/values.yaml
@@ -24,6 +24,13 @@ ingress:
   host:
     - confidant.example.com
 
+securityContext:
+  runAsNonRoot: false
+  privileged: false
+  allowPrivilegeEscalation: false
+  runAsUser: 10001
+  runAsGroup: 10001
+
 environment: {}
 
 authModule: "saml"


### PR DESCRIPTION
Add securityContext to Container runtime

* Added runAsNonRoot (default `false`)
* Added privileged (default `false`)
* Added allowPrivilegeEscalation (default `false`)
* Added runAsUser (Set if runAsNonRoot is `true`)
* Added runAsGroup (Set if runAsNonRoot is `true`)

`runAsNonRoot` is set to false which will not set the `runAsUser` and `runAsGroup` Security Contexts, this will allow the Confidant Base Image lyft/confidant:6.3.0 to run as root user by default.