### PR TITLE
:sparkles: [k8s-secret-updater] Add securityContext to Container

### DIFF
--- a/stable/k8s-secret-updater/Chart.yaml
+++ b/stable/k8s-secret-updater/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes SecretUpdater
 name: k8s-secret-updater
-version: 2.3.1
+version: 2.4.0
 icon: "https://github.com/fairfaxmedia/k8s-secret-updater"
 maintainers:
   - name: Fairfax Media Operations

--- a/stable/k8s-secret-updater/README.md
+++ b/stable/k8s-secret-updater/README.md
@@ -63,3 +63,12 @@ See the [k8s-secret-updater](https://github.com/fairfaxmedia/k8s-secret-updater)
 | `serviceAccount.create` | `false` | Create a service account with `.Chart.Name` as the name or if `serviceAccount.name`  set will use this as the name |
 | `serviceAccount.name`   | `""`    | Include a service account by its name. If `serviceAccount.create` is `true` use this name when creating the service account |
 | `serviceAccount.annotations` | `{}` | .. |
+
+### Security Context
+
+| Parameter                                  | Default | Description |
+| `securityContext.runAsNonRoot`             | `false` | If `true` containers must be required to run as non-root users. |
+| `securityContext.privileged`               | `false` | Run container in privileged mode. |
+| `securityContext.allowPrivilegeEscalation` | `false` | Controls whether a process can gain more privileges than its parent process. |
+| `securityContext.runAsUser`                | `10001` | The UID that the container's main process should run as.  |
+| `securityContext.runAsGroup`               | `10001` | The GID that the container's main process should run as.  |

--- a/stable/k8s-secret-updater/templates/app-deploy.yaml
+++ b/stable/k8s-secret-updater/templates/app-deploy.yaml
@@ -35,6 +35,14 @@ spec:
         - name: {{ .Chart.Name }}
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            privileged: {{ .Values.securityContext.privileged }}
+            allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+          {{- if eq .Values.securityContext.runAsNonRoot true }}
+            runAsUser: {{ .Values.securityContext.runAsUser }}
+            runAsGroup: {{ .Values.securityContext.runAsGroup }}
+          {{- end }}
           env:
             - name: DEBUG
               value: {{ .Values.confidant.debug | quote }}

--- a/stable/k8s-secret-updater/values.yaml
+++ b/stable/k8s-secret-updater/values.yaml
@@ -37,3 +37,9 @@ saml:
   confidantUrlRoot: "https://confidant.example.com/"
 apiVersionOverrides:
   ingress: "networking.k8s.io/v1"
+securityContext:
+  runAsNonRoot: false
+  privileged: false
+  allowPrivilegeEscalation: false
+  runAsUser: 10001
+  runAsGroup: 10001


### PR DESCRIPTION
Add securityContext to Container runtime

Added runAsNonRoot (default false)
Added privileged (default false)
Added allowPrivilegeEscalation (default false)
Added runAsUser (Set if runAsNonRoot is true)
Added runAsGroup (Set if runAsNonRoot is true)

runAsNonRoot is set to false which will not set the runAsUser and runAsGroup Security Contexts, this will allow the k8s-secret-updater Image `ffxio/k8s-secret-updater` to run as root user by default.