### PR TITLE
:bug: [k8s-secret-updater] Add volume mount for the AWS cache directory

### DIFF
--- a/stable/k8s-secret-updater/Chart.yaml
+++ b/stable/k8s-secret-updater/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes SecretUpdater
 name: k8s-secret-updater
-version: 2.3.1
+version: 2.4.1
 icon: "https://github.com/fairfaxmedia/k8s-secret-updater"
 maintainers:
   - name: Fairfax Media Operations

--- a/stable/k8s-secret-updater/templates/app-deploy.yaml
+++ b/stable/k8s-secret-updater/templates/app-deploy.yaml
@@ -83,3 +83,11 @@ spec:
             timeoutSeconds: 3
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+
+          volumeMounts:
+          - mountPath: /.aws
+            name: aws-cache
+
+      volumes:
+        - name: aws-cache
+          emptyDir: {}


### PR DESCRIPTION
Add volume mount for the AWS cache directory. This should fix an issue when running `aws-cli` command and getting permission error when running container as non root user.

**See current issue here**
https://github.com/fairfaxmedia/k8s-secret-updater/issues/30