### PR TITLE
:sparkles: [inbucket] Split services between admin and mail

### DIFF
--- a/stable/inbucket/.helmignore
+++ b/stable/inbucket/.helmignore
@@ -1,0 +1,22 @@
+
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/inbucket/Chart.yaml
+++ b/stable/inbucket/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+description: Disposable webmail server (similar to Mailinator) with built in SMTP, POP3, RESTful servers; no DB required.
+name: inbucket
+type: application
+appVersion: 3.0.4
+version: 2.2.0
+keywords:
+  - inbucket
+  - mail
+  - smtp
+  - pop3
+  - email
+  - testing
+  - disposable webmail
+home: https://www.inbucket.org/
+sources:
+  - https://github.com/inbucket/inbucket
+maintainers:
+  - name: cpanato
+    email: ctadeu@gmail.com
+
+annotations:
+  artifacthub.io/license: MIT

--- a/stable/inbucket/templates/NOTES.txt
+++ b/stable/inbucket/templates/NOTES.txt
@@ -1,0 +1,34 @@
+Inbucket can be accessed via ports {{ .Values.admin.service.port.http }} (HTTP) and {{ .Values.service.port.smtp }} (SMTP) on the following DNS name from within your cluster:
+{{ include "inbucket.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+
+If you'd like to test your instance, forward the ports locally:
+
+Web UI:
+=======
+
+export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ include "inbucket.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME {{ .Values.admin.service.port.http }}
+
+or
+
+kubectl port-forward --namespace {{ .Release.Namespace }} service/{{ include "inbucket.fullname" . }}-admin {{ .Values.admin.service.port.http }}
+
+SMTP Server:
+============
+
+export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ include "inbucket.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME {{ .Values.service.port.smtp }}
+
+or
+
+kubectl port-forward --namespace {{ .Release.Namespace }} service/{{ include "inbucket.fullname" . }} {{ .Values.service.port.smtp }}
+
+POP3 Server:
+============
+
+export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ include "inbucket.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME {{ .Values.service.port.pop3 }}
+
+or
+
+kubectl port-forward --namespace {{ .Release.Namespace }} service/{{ include "inbucket.fullname" . }} {{ .Values.service.port.pop3 }}

--- a/stable/inbucket/templates/_helpers.tpl
+++ b/stable/inbucket/templates/_helpers.tpl
@@ -1,0 +1,71 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "inbucket.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "inbucket.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "inbucket.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name for the tls secret.
+*/}}
+{{- define "inbucket.tlsSecret" -}}
+    {{- if .Values.ingress.tls.existingSecret -}}
+        {{- .Values.ingress.tls.existingSecret -}}
+    {{- else -}}
+        {{- template "inbucket.fullname" . -}}-tls
+    {{- end -}}
+{{- end -}}
+
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "inbucket.ingress.apiVersion" -}}
+  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19-0" .Capabilities.KubeVersion.Version) -}}
+      {{- print "networking.k8s.io/v1" -}}
+  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Return if ingress is stable.
+*/}}
+{{- define "inbucket.ingress.isStable" -}}
+  {{- eq (include "inbucket.ingress.apiVersion" .) "networking.k8s.io/v1" -}}
+{{- end -}}
+
+{{/*
+Return if ingress supports pathType.
+*/}}
+{{- define "inbucket.ingress.supportsPathType" -}}
+  {{- or (eq (include "inbucket.ingress.isStable" .) "true") (and (eq (include "inbucket.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" .Capabilities.KubeVersion.Version)) -}}
+{{- end -}}

--- a/stable/inbucket/templates/configmap.yaml
+++ b/stable/inbucket/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "inbucket.name" . }}-configmap
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "inbucket.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "inbucket.chart" . }}
+data:
+{{ toYaml .Values.extraEnv | indent 2 }}

--- a/stable/inbucket/templates/deployment.yaml
+++ b/stable/inbucket/templates/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ include "inbucket.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "inbucket.chart" . }}
+  name: {{ include "inbucket.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "inbucket.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+    {{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
+    {{- end }}
+      labels:
+        app.kubernetes.io/name: {{ include "inbucket.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        helm.sh/chart: {{ include "inbucket.chart" . }}
+    spec:
+      containers:
+        - name: {{ include "inbucket.name" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          envFrom:
+          - configMapRef:
+              name: {{ include "inbucket.name" . }}-configmap
+          ports:
+            - name: http
+              containerPort: 9000
+              protocol: TCP
+            - name: smtp
+              containerPort: 2500
+              protocol: TCP
+            - name: pop3
+              containerPort: 1100
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: smtp
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            tcpSocket:
+              port: smtp
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}

--- a/stable/inbucket/templates/ingress.yaml
+++ b/stable/inbucket/templates/ingress.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.ingress.enabled -}}
+{{- $ingressApiIsStable := eq (include "inbucket.ingress.isStable" .) "true" -}}
+{{- $ingressSupportsPathType := eq (include "inbucket.ingress.supportsPathType" .) "true" -}}
+{{- $fullName := include "inbucket.fullname" . -}}
+apiVersion: {{ include "inbucket.ingress.apiVersion" . }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "inbucket.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "inbucket.chart" . }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+        - path: {{ .path }}
+          {{- if $ingressSupportsPathType }}
+          pathType: {{ default "ImplementationSpecific" .pathType }}
+          {{- end }}
+          backend:
+            {{- if $ingressApiIsStable }}
+            service:
+              name: {{ $fullName }}-admin
+              port:
+                name: http
+            {{- else }}
+            serviceName: {{ $fullName }}-admin
+            servicePort: http
+            {{- end }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/stable/inbucket/templates/service-admin.yaml
+++ b/stable/inbucket/templates/service-admin.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Values.admin.service.annotations }}
+  annotations:
+{{ toYaml .Values.admin.service.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "inbucket.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "inbucket.chart" . }}
+  name: {{ include "inbucket.fullname" . }}-admin
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: "{{ .Values.admin.service.type }}"
+{{- if .Values.admin.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.admin.service.externalIPs | indent 4 }}
+{{- end }}
+{{- if .Values.admin.service.loadBalancerIP }}
+  loadBalancerIP: "{{ .Values.admin.service.loadBalancerIP }}"
+{{- end }}
+{{- if .Values.admin.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.admin.service.loadBalancerSourceRanges | indent 4 }}
+{{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.admin.service.port.http }}
+      protocol: TCP
+      targetPort: http
+      {{- if (and (eq .Values.admin.service.type "NodePort") (not (empty .Values.admin.service.nodePort.http))) }}
+      nodePort: {{ .Values.admin.service.nodePort.http }}
+      {{- end }}
+  selector:
+    app.kubernetes.io/name: {{ include "inbucket.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/stable/inbucket/templates/service.yaml
+++ b/stable/inbucket/templates/service.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "inbucket.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "inbucket.chart" . }}
+  name: {{ include "inbucket.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: "{{ .Values.service.type }}"
+{{- if .Values.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.service.externalIPs | indent 4 }}
+{{- end }}
+{{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: "{{ .Values.service.loadBalancerIP }}"
+{{- end }}
+{{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
+{{- end }}
+  ports:
+    - name: smtp
+      port: {{ .Values.service.port.smtp }}
+      protocol: TCP
+      targetPort: smtp
+      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort.smtp))) }}
+      nodePort: {{ .Values.service.nodePort.smtp }}
+      {{- end }}
+    - name: pop3
+      port: {{ .Values.service.port.pop3 }}
+      protocol: TCP
+      targetPort: pop3
+      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort.pop3))) }}
+      nodePort: {{ .Values.service.nodePort.pop3 }}
+      {{- end }}
+  selector:
+    app.kubernetes.io/name: {{ include "inbucket.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/stable/inbucket/templates/tests/inbucket-config-test.yaml
+++ b/stable/inbucket/templates/tests/inbucket-config-test.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "inbucket.name" . }}-tests
+  labels:
+    app.kubernetes.io/name: {{ include "inbucket.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "inbucket.chart" . }}
+data:
+  run.sh: |-
+    @test "Testing Inbucket is accessible" {
+      curl --retry 48 --retry-delay 10 {{ include "inbucket.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.admin.service.port.http }}
+    }

--- a/stable/inbucket/templates/tests/inbucket-test.yaml
+++ b/stable/inbucket/templates/tests/inbucket-test.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "inbucket.name" . }}-test-{{ randAlphaNum 5 | lower }}"
+  labels:
+    app.kubernetes.io/name: {{ include "inbucket.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "inbucket.chart" . }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: {{ .Release.Name }}-test
+      image: "bats/bats"
+      command:
+      - "bash"
+      - "-c"
+      - |
+        apk add curl
+        bats -t /tests/run.sh
+      volumeMounts:
+      - mountPath: /tests
+        name: tests
+        readOnly: true
+  volumes:
+  - name: tests
+    configMap:
+      name: {{ include "inbucket.name" . }}-tests
+  restartPolicy: Never

--- a/stable/inbucket/values.yaml
+++ b/stable/inbucket/values.yaml
@@ -1,0 +1,85 @@
+image:
+  repository: inbucket/inbucket
+  tag: 3.0.0@sha256:1f10a0efea694592c06799c729aee1d6d71c9a4f72b73031d4a426ef5f26dfc1
+  pullPolicy: Always
+
+service:
+  annotations: {}
+  externalIPs: []
+  loadBalancerIP: ""
+  loadBalancerSourceRanges: []
+  type: ClusterIP
+  port:
+    smtp: 2500
+    pop3: 1100
+  nodePort:
+    smtp: ""
+    pop3: ""
+
+admin:
+  service:
+    annotations: {}
+    externalIPs: []
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
+    type: ClusterIP
+    port:
+      http: 9000
+    nodePort:
+      http: ""
+
+extraEnv:
+  INBUCKET_LOGLEVEL: "info"
+  INBUCKET_MAILBOXNAMING: "local"
+  INBUCKET_SMTP_ADDR: "0.0.0.0:2500"
+  INBUCKET_SMTP_DOMAIN: "inbucket"
+  INBUCKET_SMTP_MAXRECIPIENTS: "200"
+  INBUCKET_SMTP_MAXMESSAGEBYTES: "10240000"
+  INBUCKET_SMTP_DEFAULTACCEPT: "true"
+  INBUCKET_SMTP_ACCEPTDOMAINS: ""
+  INBUCKET_SMTP_REJECTDOMAINS: ""
+  INBUCKET_SMTP_DEFAULTSTORE: "true"
+  INBUCKET_SMTP_STOREDOMAINS: ""
+  INBUCKET_SMTP_DISCARDDOMAINS: ""
+  INBUCKET_SMTP_TIMEOUT: "300s"
+  INBUCKET_SMTP_TLSENABLED: "false"
+  INBUCKET_SMTP_TLSPRIVKEY: "cert.key"
+  INBUCKET_SMTP_TLSCERT: "cert.crt"
+  INBUCKET_POP3_ADDR: "0.0.0.0:1100"
+  INBUCKET_POP3_DOMAIN: "inbucket"
+  INBUCKET_POP3_TIMEOUT: "600s"
+  INBUCKET_WEB_ADDR: "0.0.0.0:9000"
+  INBUCKET_WEB_BASEPATH: ""
+  INBUCKET_WEB_UIDIR: "ui"
+  INBUCKET_WEB_GREETINGFILE: "ui/greeting.html"
+  INBUCKET_WEB_TEMPLATECACHE: "true"
+  INBUCKET_WEB_MAILBOXPROMPT: "@inbucket"
+  INBUCKET_WEB_COOKIEAUTHKEY: ""
+  INBUCKET_WEB_MONITORVISIBLE: "true"
+  INBUCKET_WEB_MONITORHISTORY: "30"
+  INBUCKET_STORAGE_TYPE: "memory"
+  INBUCKET_WEB_PPROF: "false"
+  INBUCKET_STORAGE_PARAMS: ""
+  INBUCKET_STORAGE_RETENTIONPERIOD: "24h"
+  INBUCKET_STORAGE_RETENTIONSLEEP: "50ms"
+  INBUCKET_STORAGE_MAILBOXMSGCAP: "500"
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: inbucket.example.com
+      paths:
+        - path: /
+          # -- pathType (e.g. ImplementationSpecific, Prefix, .. etc.)
+          # pathType: Prefix
+
+  tls: []
+  #  - secretName: inbucket-example-tls
+  #    hosts:
+  #      - inbucket.example.com
+
+podAnnotations: {}
+resources: {}


### PR DESCRIPTION
Split services to allow the admin interface to be managed independently from the mail receiver.

This allows for the web interface to have access controls (via the ingress) while still allowing open access to receive email on the SMTP or POP3 port.