### PR TITLE
[inbucket] Split services between admin and mail

### DIFF
--- a/stable/inbucket/Chart.yaml
+++ b/stable/inbucket/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 description: Disposable webmail server (similar to Mailinator) with built in SMTP, POP3, RESTful servers; no DB required.
 name: inbucket
 type: application
-appVersion: 3.0.0
-version: 2.1.0
+appVersion: 3.0.4
+version: 2.2.0
 keywords:
   - inbucket
   - mail

--- a/stable/inbucket/templates/NOTES.txt
+++ b/stable/inbucket/templates/NOTES.txt
@@ -1,4 +1,4 @@
-Inbucket can be accessed via ports {{ .Values.service.port.http }} (HTTP) and {{ .Values.service.port.smtp }} (SMTP) on the following DNS name from within your cluster:
+Inbucket can be accessed via ports {{ .Values.admin.service.port.http }} (HTTP) and {{ .Values.service.port.smtp }} (SMTP) on the following DNS name from within your cluster:
 {{ include "inbucket.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 
 If you'd like to test your instance, forward the ports locally:
@@ -7,11 +7,11 @@ Web UI:
 =======
 
 export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ include "inbucket.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME {{ .Values.service.port.http }}
+kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME {{ .Values.admin.service.port.http }}
 
 or
 
-kubectl port-forward --namespace {{ .Release.Namespace }} service/{{ include "inbucket.fullname" . }} {{ .Values.service.port.http }}
+kubectl port-forward --namespace {{ .Release.Namespace }} service/{{ include "inbucket.fullname" . }}-admin {{ .Values.admin.service.port.http }}
 
 SMTP Server:
 ============

--- a/stable/inbucket/templates/ingress.yaml
+++ b/stable/inbucket/templates/ingress.yaml
@@ -40,11 +40,11 @@ spec:
           backend:
             {{- if $ingressApiIsStable }}
             service:
-              name: {{ $fullName }}
+              name: {{ $fullName }}-admin
               port:
                 name: http
             {{- else }}
-            serviceName: {{ $fullName }}
+            serviceName: {{ $fullName }}-admin
             servicePort: http
             {{- end }}
         {{- end }}

--- a/stable/inbucket/templates/service-admin.yaml
+++ b/stable/inbucket/templates/service-admin.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Values.admin.service.annotations }}
+  annotations:
+{{ toYaml .Values.admin.service.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "inbucket.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "inbucket.chart" . }}
+  name: {{ include "inbucket.fullname" . }}-admin
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: "{{ .Values.admin.service.type }}"
+{{- if .Values.admin.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.admin.service.externalIPs | indent 4 }}
+{{- end }}
+{{- if .Values.admin.service.loadBalancerIP }}
+  loadBalancerIP: "{{ .Values.admin.service.loadBalancerIP }}"
+{{- end }}
+{{- if .Values.admin.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.admin.service.loadBalancerSourceRanges | indent 4 }}
+{{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.admin.service.port.http }}
+      protocol: TCP
+      targetPort: http
+      {{- if (and (eq .Values.admin.service.type "NodePort") (not (empty .Values.admin.service.nodePort.http))) }}
+      nodePort: {{ .Values.admin.service.nodePort.http }}
+      {{- end }}
+  selector:
+    app.kubernetes.io/name: {{ include "inbucket.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/stable/inbucket/templates/service.yaml
+++ b/stable/inbucket/templates/service.yaml
@@ -26,13 +26,6 @@ spec:
 {{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
 {{- end }}
   ports:
-    - name: http
-      port: {{ .Values.service.port.http }}
-      protocol: TCP
-      targetPort: http
-      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort.http))) }}
-      nodePort: {{ .Values.service.nodePort.http }}
-      {{- end }}
     - name: smtp
       port: {{ .Values.service.port.smtp }}
       protocol: TCP

--- a/stable/inbucket/templates/tests/inbucket-config-test.yaml
+++ b/stable/inbucket/templates/tests/inbucket-config-test.yaml
@@ -10,5 +10,5 @@ metadata:
 data:
   run.sh: |-
     @test "Testing Inbucket is accessible" {
-      curl --retry 48 --retry-delay 10 {{ include "inbucket.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port.http }}
+      curl --retry 48 --retry-delay 10 {{ include "inbucket.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.admin.service.port.http }}
     }

--- a/stable/inbucket/values.yaml
+++ b/stable/inbucket/values.yaml
@@ -10,13 +10,23 @@ service:
   loadBalancerSourceRanges: []
   type: ClusterIP
   port:
-    http: 9000
     smtp: 2500
     pop3: 1100
   nodePort:
-    http: ""
     smtp: ""
     pop3: ""
+
+admin:
+  service:
+    annotations: {}
+    externalIPs: []
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
+    type: ClusterIP
+    port:
+      http: 9000
+    nodePort:
+      http: ""
 
 extraEnv:
   INBUCKET_LOGLEVEL: "info"


### PR DESCRIPTION
Split services to allow the admin interface to be managed independently from the mail receiver.

This allows for the web interface to have access controls (via the ingress) while still allowing open access to receive email on the SMTP or POP3 port.