### PR TITLE
[kafdrop] Fix application failure

### DIFF
--- a/stable/kafdrop/Chart.yaml
+++ b/stable/kafdrop/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: 3.30.0
 description: A Helm chart for Kafdrop
 name: kafdrop
-version: 0.2.0
+version: 0.2.1

--- a/stable/kafdrop/templates/deployment.yaml
+++ b/stable/kafdrop/templates/deployment.yaml
@@ -24,18 +24,13 @@ spec:
 {{- end }}
     spec:
       automountServiceAccountToken: false
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
             capabilities:
               drop:
                 - all
-            readOnlyRootFilesystem: true
+            readOnlyRootFilesystem: false
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:

--- a/stable/kafdrop/templates/ingress.yaml
+++ b/stable/kafdrop/templates/ingress.yaml
@@ -31,8 +31,11 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+               name: {{ $fullName }}
+               port:
+                 number: 80
   {{- end }}
 {{- end }}


### PR DESCRIPTION
The Kafdrop chart was unable to successfully create a working service due to a number of issues.

Setting the root filesystem to read only prevented the application from writing to /tmp.

Running the application as a non root user caused the web interface to hang when rendering the main view.

The ingress was incorrectly configured and caused Kubernetes to output a schema failure error.