### PR TITLE
Update Snappass app version

### DIFF
--- a/stable/snappass/Chart.yaml
+++ b/stable/snappass/Chart.yaml
@@ -1,8 +1,8 @@
-apiVersion: v1
-appVersion: "1.6.0"
+apiVersion: v2
+appVersion: "1.7.2"
 description: Share passwords securely
 name: snappass
-version: 0.2.1
+version: 0.3.0
 sources:
   - https://github.com/pinterest/snappass
 maintainers:

--- a/stable/snappass/requirements.lock
+++ b/stable/snappass/requirements.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   version: 17.0.1
 digest: sha256:971c7d3e44106de73552c8dee38509fd10b0ed4d08d308ed94e5249d1862e427
-generated: "2023-01-16T16:00:18.2888+11:00"
+generated: "2025-07-14T12:00:23.396611+10:00"

--- a/stable/snappass/values.yaml
+++ b/stable/snappass/values.yaml
@@ -5,8 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: fairfaxmedia/snappass
-  tag: 1.6.0
+  repository: ghcr.io/nine-entertainment/snappass
+  tag: v1.7.2
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
Update `snappass` to the latest tag release which brings in all the upstream changes into our fork.